### PR TITLE
ScriptLanguage::frame can not be implmented

### DIFF
--- a/rust-script/src/runtime/rust_script_language.rs
+++ b/rust-script/src/runtime/rust_script_language.rs
@@ -8,7 +8,6 @@ use std::ffi::OsStr;
 
 use godot::{
     engine::{Engine, FileAccess, IScriptLanguageExtension, ProjectSettings, Script},
-    log::godot_print,
     obj::Base,
     prelude::{
         godot_api, Array, Dictionary, GString, Gd, GodotClass, Object, PackedStringArray,
@@ -228,8 +227,4 @@ impl IScriptLanguageExtension for RustScriptLanguage {
 
     // godot hook to trigger script reload
     fn reload_all_scripts(&mut self) {}
-
-    fn frame(&mut self) {
-        godot_print!("script language frame called!");
-    }
 }


### PR DESCRIPTION
`ScriptLanguage::frame` cannot be implemented until thread blocking for `GdCell` has been merged in [godot-rust/gdext](https://github.com/godot-rust/gdext).