### PR TITLE
Godot 4.3 no longer has the internal editor toast API

### DIFF
--- a/rust-script/src/editor_ui_hacks.rs
+++ b/rust-script/src/editor_ui_hacks.rs
@@ -36,6 +36,7 @@ impl ToGodot for EditorToasterSeverity {
     }
 }
 
+#[expect(dead_code)]
 pub fn show_editor_toast(message: &str, severity: EditorToasterSeverity) {
     if !Engine::singleton().is_editor_hint() {
         return;

--- a/rust-script/src/runtime/rust_script_language.rs
+++ b/rust-script/src/runtime/rust_script_language.rs
@@ -10,7 +10,7 @@ use godot::classes::native::ScriptLanguageExtensionProfilingInfo;
 #[cfg(since_api = "4.3")]
 use godot::classes::script_language::ScriptNameCasing;
 use godot::classes::{Engine, FileAccess, IScriptLanguageExtension, ProjectSettings, Script};
-use godot::global;
+use godot::global::{self, godot_error};
 use godot::obj::Base;
 use godot::prelude::{
     godot_api, Array, Dictionary, GString, Gd, GodotClass, Object, PackedStringArray, StringName,
@@ -19,7 +19,6 @@ use godot::prelude::{
 use itertools::Itertools;
 
 use crate::apply::Apply;
-use crate::editor_ui_hacks::{show_editor_toast, EditorToasterSeverity};
 use crate::static_script_registry::RustScriptMetaData;
 
 use super::{rust_script::RustScript, SCRIPT_REGISTRY};
@@ -204,10 +203,8 @@ impl IScriptLanguageExtension for RustScriptLanguage {
         _line: i32,
         _col: i32,
     ) -> global::Error {
-        show_editor_toast(
-            "Editing rust scripts from inside Godot is currently not supported.",
-            EditorToasterSeverity::Warning,
-        );
+        // TODO: From Godot 4.4 we can show an editor toast here. Just waiting for a new gdext release.
+        godot_error!("Editing rust scripts from inside Godot is currently not supported.");
 
         global::Error::OK
     }


### PR DESCRIPTION
In Godot 4.2 and earlier, there was an internal undocumented editor toast API that allowed to show a toast message to the user. Such a message was used to indicate that editing rust scripts from inside the Godot editor is not available. Unfortunately, this API was removed in Godot 4.3, but then was turned in a proper public API with Godot 4.4.

For now, the toast message has been replaced with an error log message. Once gdext support for the Godot 4.4 API is released, we will show a toast from 4.4 onwards. 