### PR TITLE
Upgrade to gdext 0.3 #72

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,21 +72,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "gdextension-api"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8707eca996b28193b772a4a9a28a97364bb93c97e3c313542e812f2963fb93"
-
-[[package]]
-name = "gensym"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913dce4c5f06c2ea40fc178c06f777ac89fc6b1383e90c254fafb1abe4ba3c82"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "uuid",
-]
+checksum = "2ec0a03c8f9c91e3d8eb7ca56dea81c7248c03826dd3f545f33cd22ef275d4d1"
 
 [[package]]
 name = "getrandom"
@@ -101,15 +89,15 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.28.0"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
+checksum = "6b46b9ca4690308844c644e7c634d68792467260e051c8543e0c7871662b3ba7"
 
 [[package]]
 name = "godot"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29a3646d4b02bf4587fedba4ac7b44a47d45c933fd85ba7e61292408818eaa4"
+checksum = "8be80775e8e898b3eb778324edb8184abe69b8ce1f8c9ddefdb3ca3c29dbf807"
 dependencies = [
  "godot-core",
  "godot-macros",
@@ -117,24 +105,24 @@ dependencies = [
 
 [[package]]
 name = "godot-bindings"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0014540bff93ba275031bc852f1cf9a3ff3216f02cdd51dc249745dccc8c578"
+checksum = "ffae5f2ac74e199b620c9423a63d07d1d256727ae10b8fd5f4dd1b7d0ad6e53a"
 dependencies = [
  "gdextension-api",
 ]
 
 [[package]]
 name = "godot-cell"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88184d525d763ebc88ff6806ffee35e19c7118d5c9e4eedbc74e70e069f8a671"
+checksum = "359a01b262bb181fddcfabc529da221ca5045b264a07546ed1976efd0feefc06"
 
 [[package]]
 name = "godot-codegen"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa72d9b8be812fef2932f2a172b80c8b3feaee030571682f8f770c3d1c348d8"
+checksum = "7df7b4edf35977ab5f448fd99087725307ac6e6b88c957a61b02ec556a0fedf8"
 dependencies = [
  "godot-bindings",
  "heck",
@@ -146,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "godot-core"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff8345372e4c990ca592d7b61490ef88ff249fc77226f5b79beca173b4a0458"
+checksum = "21b55f9a4003ff887a8729820c0c8b4db84cb17d623e77a847d31fc69db1cf33"
 dependencies = [
  "glam",
  "godot-bindings",
@@ -159,24 +147,24 @@ dependencies = [
 
 [[package]]
 name = "godot-ffi"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "606d08085bd590d2f9c72633d4d218fee665ab3a0760b2d9daff2d964d628def"
+checksum = "d5b1d3fffcbd583091476f1ae0c1482e5413f2d97ce30829198bae6cd4db468e"
 dependencies = [
- "gensym",
  "godot-bindings",
  "godot-codegen",
+ "godot-macros",
  "libc",
- "paste",
 ]
 
 [[package]]
 name = "godot-macros"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c11b3188e54ebacf88feb4c968ed19048a71a329c4cfd4a06cf374f18357a36"
+checksum = "d0c19bc6f536e07249efc37cdda01ccd72aa0a6c05cd135f540c5cf5abbdaae1"
 dependencies = [
  "godot-bindings",
+ "libc",
  "proc-macro2",
  "quote",
  "venial",
@@ -233,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "memchr"
@@ -245,30 +233,24 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "nanoserde"
-version = "0.1.35"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a983d0b19ed0fcd803c4f04f9b20d5e6dd17e06d44d98742a0985ac45dab1bc"
+checksum = "a36fb3a748a4c9736ed7aeb5f2dfc99665247f1ce306abbddb2bf0ba2ac530a4"
 dependencies = [
  "nanoserde-derive",
 ]
 
 [[package]]
 name = "nanoserde-derive"
-version = "0.1.21"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4dc96541767a4279572fdcf9f95af9cc1c9b2a2254e7a079203c81e206a9059"
+checksum = "a846cbc04412cf509efcd8f3694b114fc700a035fb5a37f21517f9fb019f1ebc"
 
 [[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "paste"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "ppv-lite86"
@@ -287,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -326,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -338,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -349,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "strsim"
@@ -402,15 +384,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "uuid"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "venial"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ version = "0.1.0"
 edition = "2021"
 
 [workspace.dependencies]
-godot = { version = "0.2", features = ["experimental-threads"] }
-godot-cell = "0.2"
-godot-bindings = "0.2"
+godot = { version = "0.3", features = ["experimental-threads"] }
+godot-cell = "0.3"
+godot-bindings = "0.3"
 itertools = "0.10"
 rand = "0.8"
 darling = { version = "0.20" }

--- a/derive/src/impl_attribute.rs
+++ b/derive/src/impl_attribute.rs
@@ -60,13 +60,13 @@ pub fn godot_script_impl(
                     let arg_rust_type = arg.ty.as_ref();
                     let arg_type = rust_to_variant_type(arg.ty.as_ref()).unwrap();
 
-                    is_context_type(arg.ty.as_ref()).then(|| {
+                    if is_context_type(arg.ty.as_ref()) { 
                         (
                             quote!(),
 
                             quote_spanned!(arg.span() => ctx,)
                         )
-                    }).unwrap_or_else(|| {
+                    } else { 
                         (
                             quote_spanned! {
                                 arg.span() =>
@@ -91,7 +91,7 @@ pub fn godot_script_impl(
                                 })?,
                             }
                         )
-                    })
+                    }
                 })
                 .collect();
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -184,7 +184,7 @@ fn rust_to_variant_type(ty: &syn::Type) -> Result<TokenStream, TokenStream> {
                 use #godot_types::sys::GodotFfi;
                 use #godot_types::meta::GodotType;
 
-                <<#path as #godot_types::meta::GodotConvert>::Via as GodotType>::Ffi::variant_type()
+                <<#path as #godot_types::meta::GodotConvert>::Via as GodotType>::Ffi::VARIANT_TYPE
             }
         }),
         T::Verbatim(_) => Err(syn::Error::new(
@@ -206,7 +206,7 @@ fn rust_to_variant_type(ty: &syn::Type) -> Result<TokenStream, TokenStream> {
                     use #godot_types::sys::GodotFfi;
                     use #godot_types::meta::GodotType;
 
-                    <<#tuple as #godot_types::meta::GodotConvert>::Via as GodotType>::Ffi::variant_type()
+                    <<#tuple as #godot_types::meta::GodotConvert>::Via as GodotType>::Ffi::VARIANT_TYPE
                 }
             })
         }

--- a/rust-script/src/interface.rs
+++ b/rust-script/src/interface.rs
@@ -204,7 +204,7 @@ macro_rules! define_script_root {
             use $crate::godot::obj::EngineEnum;
             use $crate::private_export::*;
 
-            let lock = $crate::private_export::__godot_rust_plugin_SCRIPT_REGISTRY
+            let lock = $crate::private_export::SCRIPT_REGISTRY
                 .lock()
                 .expect("unable to aquire mutex lock");
 

--- a/rust-script/src/interface/export.rs
+++ b/rust-script/src/interface/export.rs
@@ -95,7 +95,7 @@ where
 
 impl<T: ArrayElement + GodotScriptExport + GodotType> GodotScriptExport for Array<T> {
     fn hint_string(custom_hint: Option<PropertyHint>, custom_string: Option<String>) -> String {
-        let element_type = <<T as GodotType>::Ffi as GodotFfi>::variant_type().ord();
+        let element_type = <<T as GodotType>::Ffi as GodotFfi>::VARIANT_TYPE.ord();
         let element_hint = <T as GodotScriptExport>::hint(custom_hint).ord();
         let element_hint_string = <T as GodotScriptExport>::hint_string(custom_hint, custom_string);
 

--- a/rust-script/src/interface/signals.rs
+++ b/rust-script/src/interface/signals.rs
@@ -123,7 +123,7 @@ macro_rules! signal_argument_desc {
     ($name:literal, $type:ty) => {
         RustScriptPropDesc {
             name: $name,
-            ty: <<<$type as GodotConvert>::Via as GodotType>::Ffi as godot::sys::GodotFfi>::variant_type(),
+            ty: <<<$type as GodotConvert>::Via as GodotType>::Ffi as godot::sys::GodotFfi>::VARIANT_TYPE,
             class_name: <<$type as GodotConvert>::Via as GodotType>::class_name(),
             exported: false,
             hint: PropertyHint::NONE,

--- a/rust-script/src/lib.rs
+++ b/rust-script/src/lib.rs
@@ -18,9 +18,9 @@ pub use runtime::RustScriptExtensionLayer;
 #[doc(hidden)]
 pub mod private_export {
     pub use crate::static_script_registry::{
-        RustScriptMetaData, __godot_rust_plugin_SCRIPT_REGISTRY, assemble_metadata,
-        create_default_data_struct, RegistryItem, RustScriptEntry, RustScriptEntryMethods,
-        RustScriptMethodDesc, RustScriptPropDesc, RustScriptSignalDesc,
+        assemble_metadata, create_default_data_struct, RegistryItem, RustScriptEntry,
+        RustScriptEntryMethods, RustScriptMetaData, RustScriptMethodDesc, RustScriptPropDesc,
+        RustScriptSignalDesc, SCRIPT_REGISTRY,
     };
     pub use const_str::{concat, replace, strip_prefix, unwrap};
     pub use godot::sys::{plugin_add, plugin_registry};

--- a/rust-script/src/runtime/rust_script.rs
+++ b/rust-script/src/runtime/rust_script.rs
@@ -13,7 +13,7 @@ use godot::classes::{
 use godot::global::{godot_error, godot_print, godot_warn, PropertyUsageFlags};
 use godot::meta::{MethodInfo, PropertyInfo, ToGodot};
 use godot::obj::script::create_script_instance;
-use godot::obj::{EngineBitfield, EngineEnum, InstanceId, WithBaseField};
+use godot::obj::{EngineBitfield, InstanceId, WithBaseField};
 use godot::prelude::{
     godot_api, Array, Base, Callable, Dictionary, GString, Gd, GodotClass, StringName, Variant,
     VariantArray,
@@ -183,7 +183,7 @@ impl IScriptExtension for RustScript {
         false
     }
 
-    unsafe fn instance_create(&self, mut for_object: Gd<Object>) -> *mut c_void {
+    unsafe fn instance_create_rawptr(&self, mut for_object: Gd<Object>) -> *mut c_void {
         self.owners.borrow_mut().insert(for_object.instance_id());
 
         let data = self.create_remote_instance(for_object.clone());
@@ -203,7 +203,7 @@ impl IScriptExtension for RustScript {
         create_script_instance(instance, for_object)
     }
 
-    unsafe fn placeholder_instance_create(&self, for_object: Gd<Object>) -> *mut c_void {
+    unsafe fn placeholder_instance_create_rawptr(&self, for_object: Gd<Object>) -> *mut c_void {
         self.owners.borrow_mut().insert(for_object.instance_id());
 
         let placeholder = RustScriptPlaceholder::new(self.to_gd());

--- a/rust-script/src/runtime/rust_script_language.rs
+++ b/rust-script/src/runtime/rust_script_language.rs
@@ -357,7 +357,7 @@ impl IScriptLanguageExtension for RustScriptLanguage {
     }
 
     #[expect(unused_variables)]
-    unsafe fn debug_get_stack_level_instance(&mut self, level: i32) -> *mut c_void {
+    unsafe fn debug_get_stack_level_instance_rawptr(&mut self, level: i32) -> *mut c_void {
         unimplemented!("debugging is not implemented!");
     }
 
@@ -391,7 +391,7 @@ impl IScriptLanguageExtension for RustScriptLanguage {
     fn profiling_set_save_native_calls(&mut self, enable: bool) {}
 
     #[expect(unused_variables)]
-    unsafe fn profiling_get_accumulated_data(
+    unsafe fn profiling_get_accumulated_data_rawptr(
         &mut self,
         info_array: *mut ScriptLanguageExtensionProfilingInfo,
         info_max: i32,
@@ -400,7 +400,7 @@ impl IScriptLanguageExtension for RustScriptLanguage {
     }
 
     #[expect(unused_variables)]
-    unsafe fn profiling_get_frame_data(
+    unsafe fn profiling_get_frame_data_rawptr(
         &mut self,
         info_array: *mut ScriptLanguageExtensionProfilingInfo,
         info_max: i32,

--- a/rust-script/src/static_script_registry.rs
+++ b/rust-script/src/static_script_registry.rs
@@ -26,7 +26,7 @@ godot::sys::plugin_registry!(pub SCRIPT_REGISTRY: RegistryItem);
 macro_rules! register_script_class {
     ($class_name:ty, $base_name:ty, $desc:expr, $props:expr, $signals:expr) => {
         $crate::private_export::plugin_add! {
-        SCRIPT_REGISTRY in $crate::private_export;
+            $crate::private_export::SCRIPT_REGISTRY;
             $crate::private_export::RegistryItem::Entry($crate::private_export::RustScriptEntry {
                 class_name: stringify!($class_name),
                 class_name_cstr: ::std::ffi::CStr::from_bytes_with_nul(concat!(stringify!($class_name), "\0").as_bytes()).unwrap(),
@@ -49,7 +49,7 @@ macro_rules! register_script_class {
 macro_rules! register_script_class {
     ($class_name:ty, $base_name:ty, $desc:expr, $props:expr, $signals:expr) => {
         $crate::private_export::plugin_add! {
-        SCRIPT_REGISTRY in $crate::private_export;
+            $crate::private_export::SCRIPT_REGISTRY ;
             $crate::private_export::RegistryItem::Entry($crate::private_export::RustScriptEntry {
                 class_name: stringify!($class_name),
                 base_type_name: <$base_name as $crate::godot::prelude::GodotClass>::class_name().to_cow_str(),
@@ -70,7 +70,7 @@ macro_rules! register_script_class {
 macro_rules! register_script_methods {
     ($class_name:ty, $methods:expr) => {
         $crate::private_export::plugin_add! {
-            SCRIPT_REGISTRY in $crate::private_export;
+            $crate::private_export::SCRIPT_REGISTRY ;
             $crate::private_export::RegistryItem::Methods($crate::private_export::RustScriptEntryMethods {
                 class_name: stringify!($class_name),
                 methods: || {
@@ -349,7 +349,7 @@ pub struct RustScriptMetaData {
 }
 
 impl RustScriptMetaData {
-    #[expect(clippy::too_many_arguments)]
+    #[cfg_attr(before_api = "4.4", expect(clippy::too_many_arguments))]
     pub fn new(
         class_name: &'static str,
         #[cfg(before_api = "4.4")] class_name_cstr: &'static std::ffi::CStr,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.87.0"
 components = [ "rustfmt", "clippy" ]
 profile = "default"


### PR DESCRIPTION
Upgrades the gdext dependency to 0.3. This is a breaking change, rust script is now no longer compatible with gdext 0.2