### PR TITLE
Script `ClassName`s can be allocated as ASCII only or unicode

### DIFF
--- a/rust-script/src/static_script_registry.rs
+++ b/rust-script/src/static_script_registry.rs
@@ -22,7 +22,6 @@ use crate::runtime::GodotScriptObject;
 godot::sys::plugin_registry!(pub SCRIPT_REGISTRY: RegistryItem);
 
 #[macro_export]
-#[cfg(before_api = "4.4")]
 macro_rules! register_script_class {
     ($class_name:ty, $base_name:ty, $desc:expr, $props:expr, $signals:expr) => {
         $crate::private_export::plugin_add! {
@@ -30,28 +29,6 @@ macro_rules! register_script_class {
             $crate::private_export::RegistryItem::Entry($crate::private_export::RustScriptEntry {
                 class_name: stringify!($class_name),
                 class_name_cstr: ::std::ffi::CStr::from_bytes_with_nul(concat!(stringify!($class_name), "\0").as_bytes()).unwrap(),
-                base_type_name: <$base_name as $crate::godot::prelude::GodotClass>::class_name().to_cow_str(),
-                properties: || {
-                    $props
-                },
-                signals: || {
-                    $signals
-                },
-                create_data: $crate::private_export::create_default_data_struct::<$class_name>,
-                description: $desc,
-            })
-        }
-    };
-}
-
-#[macro_export]
-#[cfg(since_api = "4.4")]
-macro_rules! register_script_class {
-    ($class_name:ty, $base_name:ty, $desc:expr, $props:expr, $signals:expr) => {
-        $crate::private_export::plugin_add! {
-            $crate::private_export::SCRIPT_REGISTRY ;
-            $crate::private_export::RegistryItem::Entry($crate::private_export::RustScriptEntry {
-                class_name: stringify!($class_name),
                 base_type_name: <$base_name as $crate::godot::prelude::GodotClass>::class_name().to_cow_str(),
                 properties: || {
                     $props
@@ -83,7 +60,6 @@ macro_rules! register_script_methods {
 
 pub struct RustScriptEntry {
     pub class_name: &'static str,
-    #[cfg(before_api = "4.4")]
     pub class_name_cstr: &'static std::ffi::CStr,
     pub base_type_name: Cow<'static, str>,
     pub properties: fn() -> Vec<RustScriptPropDesc>,
@@ -145,13 +121,12 @@ impl RustScriptMethodDesc {
         self,
         id: i32,
         class_name: &'static str,
-        #[cfg(before_api = "4.4")] class_name_cstr: &'static std::ffi::CStr,
+        class_name_cstr: &'static std::ffi::CStr,
     ) -> RustScriptMethodInfo {
         RustScriptMethodInfo {
             id,
             method_name: self.name,
             class_name,
-            #[cfg(before_api = "4.4")]
             class_name_cstr,
             return_type: self.return_type.to_property_info(),
             flags: self.flags.ord(),
@@ -221,7 +196,6 @@ pub fn assemble_metadata<'a>(
                     method.into_method_info(
                         (index + 1) as i32,
                         class.class_name,
-                        #[cfg(before_api = "4.4")]
                         class.class_name_cstr,
                     )
                 })
@@ -234,7 +208,6 @@ pub fn assemble_metadata<'a>(
 
             RustScriptMetaData::new(
                 class.class_name,
-                #[cfg(before_api = "4.4")]
                 class.class_name_cstr,
                 class.base_type_name.as_ref().into(),
                 props,
@@ -281,7 +254,6 @@ pub struct RustScriptMethodInfo {
     pub id: i32,
     pub method_name: &'static str,
     pub class_name: &'static str,
-    #[cfg(before_api = "4.4")]
     pub class_name_cstr: &'static std::ffi::CStr,
     pub return_type: RustScriptPropertyInfo,
     pub arguments: Box<[RustScriptPropertyInfo]>,
@@ -294,11 +266,7 @@ impl From<&RustScriptMethodInfo> for MethodInfo {
         Self {
             id: value.id,
             method_name: value.method_name.into(),
-            class_name: ClassName::new_script(
-                value.class_name,
-                #[cfg(before_api = "4.4")]
-                value.class_name_cstr,
-            ),
+            class_name: ClassName::new_script(value.class_name, value.class_name_cstr),
             return_type: (&value.return_type).into(),
             arguments: value.arguments.iter().map(|arg| arg.into()).collect(),
             default_arguments: vec![],
@@ -349,10 +317,10 @@ pub struct RustScriptMetaData {
 }
 
 impl RustScriptMetaData {
-    #[cfg_attr(before_api = "4.4", expect(clippy::too_many_arguments))]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         class_name: &'static str,
-        #[cfg(before_api = "4.4")] class_name_cstr: &'static std::ffi::CStr,
+        class_name_cstr: &'static std::ffi::CStr,
         base_type_name: StringName,
         properties: Box<[RustScriptPropertyInfo]>,
         methods: Box<[RustScriptMethodInfo]>,
@@ -361,11 +329,8 @@ impl RustScriptMetaData {
         description: &'static str,
     ) -> Self {
         Self {
-            #[cfg(before_api = "4.4")]
             class_name: ClassName::new_script(class_name, class_name_cstr),
 
-            #[cfg(since_api = "4.4")]
-            class_name: ClassName::new_script(class_name),
             base_type_name,
             properties,
             methods,
@@ -423,15 +388,10 @@ static DYNAMIC_INDEX_BY_CLASS_NAME: LazyLock<RwLock<HashMap<&'static str, ClassN
     LazyLock::new(RwLock::default);
 
 trait ClassNameExtension {
-    #[cfg(before_api = "4.4")]
     fn new_script(str: &'static str, cstr: &'static std::ffi::CStr) -> Self;
-
-    #[cfg(since_api = "4.4")]
-    fn new_script(str: &'static str) -> Self;
 }
 
 impl ClassNameExtension for ClassName {
-    #[cfg(before_api = "4.4")]
     fn new_script(str: &'static str, cstr: &'static std::ffi::CStr) -> Self {
         // Check if class name exists.
         if let Some(name) = DYNAMIC_INDEX_BY_CLASS_NAME.read().unwrap().get(str) {
@@ -440,27 +400,36 @@ impl ClassNameExtension for ClassName {
 
         let mut map = DYNAMIC_INDEX_BY_CLASS_NAME.write().unwrap();
 
-        let class_name = map
-            .entry(str)
-            .or_insert_with(|| ClassName::alloc_next_ascii(cstr));
+        let class_name = *map.entry(str).or_insert_with(|| {
+            if str.is_ascii() {
+                ClassName::alloc_next_ascii(cstr)
+            } else {
+                ClassName::alloc_next_unicode(str)
+            }
+        });
 
-        *class_name
+        class_name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use godot::meta::ClassName;
+
+    use crate::static_script_registry::ClassNameExtension;
+
+    #[test]
+    fn new_class_name() {
+        let script_name = ClassName::new_script("TestScript", c"TestScript");
+
+        assert_eq!(script_name.to_cow_str(), "TestScript");
     }
 
     #[cfg(since_api = "4.4")]
-    fn new_script(str: &'static str) -> Self {
-        // Check if class name exists.
+    #[test]
+    fn new_unicode_class_name() {
+        let script_name = ClassName::new_script("ÜbertragungsScript", c"ÜbertragungsScript");
 
-        if let Some(name) = DYNAMIC_INDEX_BY_CLASS_NAME.read().unwrap().get(str) {
-            return *name;
-        }
-
-        let mut map = DYNAMIC_INDEX_BY_CLASS_NAME.write().unwrap();
-
-        let class_name = *map
-            .entry(str)
-            .or_insert_with(|| ClassName::alloc_next_unicode(str));
-
-        class_name
+        assert_eq!(script_name.to_cow_str(), "ÜbertragungsScript");
     }
 }


### PR DESCRIPTION
gdext wants `ClassName`s to be either allocated as ASCII only if they are 100% ASCII and otherwise as unicode. 

Resolves #74 