### PR TITLE
Refactor script refs and enable script traits

### DIFF
--- a/derive/src/impl_attribute.rs
+++ b/derive/src/impl_attribute.rs
@@ -6,15 +6,14 @@
 
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote, quote_spanned};
+use syn::spanned::Spanned;
 use syn::{
-    FnArg, Ident, ImplItem, ImplItemFn, ItemImpl, PatIdent, PatType, ReturnType, Token, Type,
-    Visibility, parse_macro_input, parse2, spanned::Spanned,
+    FnArg, Ident, ImplItem, ImplItemFn, ItemImpl, PatIdent, PatType, ReturnType, Signature, Type,
+    Visibility, parse_macro_input,
 };
 
-use crate::{
-    extract_ident_from_type, is_context_type, property_usage, rust_to_variant_type,
-    type_paths::{godot_types, property_hints, string_name_ty, variant_ty},
-};
+use crate::type_paths::{godot_types, property_hints, string_name_ty, variant_ty};
+use crate::{extract_ident_from_type, is_context_type, property_usage, rust_to_variant_type};
 
 pub fn godot_script_impl(
     _args: proc_macro::TokenStream,
@@ -203,12 +202,7 @@ pub fn godot_script_impl(
 
 fn sanitize_trait_fn_arg(arg: FnArg) -> FnArg {
     match arg {
-        FnArg::Receiver(mut rec) => {
-            rec.mutability = Some(Token![mut](rec.span()));
-            rec.ty = parse2(quote!(&mut Self)).unwrap();
-
-            FnArg::Receiver(rec)
-        }
+        FnArg::Receiver(_) => arg,
         FnArg::Typed(ty) => FnArg::Typed(PatType {
             attrs: ty.attrs,
             pat: match *ty.pat {
@@ -243,6 +237,11 @@ fn sanitize_trait_fn_arg(arg: FnArg) -> FnArg {
     }
 }
 
+struct InterfaceFn {
+    sig: Signature,
+    is_mut: bool,
+}
+
 fn generate_public_interface(impl_body: &ItemImpl) -> TokenStream {
     let impl_target = impl_body.self_ty.as_ref();
     let script_name = match extract_ident_from_type(impl_target) {
@@ -267,22 +266,34 @@ fn generate_public_interface(impl_body: &ItemImpl) -> TokenStream {
                 .into_iter()
                 .filter(|arg| {
                     !matches!(arg, FnArg::Typed(PatType { attrs: _, pat: _, colon_token: _, ty }) if matches!(ty.as_ref(), Type::Path(path) if path.path.segments.last().unwrap().ident == "Context"))
-                })
-                .map(sanitize_trait_fn_arg)
+                }).map(sanitize_trait_fn_arg)
                 .collect();
-            sig
+            let is_mut = sig.inputs.iter().any(|arg| {
+                matches!(arg, FnArg::Receiver(rec) if rec.mutability.is_some())
+            });
+
+            InterfaceFn {
+                sig,
+                is_mut
+            }
         })
         .collect();
 
     let function_defs: TokenStream = functions
         .iter()
-        .map(|func| quote_spanned! { func.span() =>  #func; })
+        .map(|func| {
+            let sig = &func.sig;
+
+            quote_spanned! { sig.span() =>  #sig; }
+        })
         .collect();
     let function_impls: TokenStream = functions
         .iter()
         .map(|func| {
-            let func_name = func.ident.to_string();
-            let args: TokenStream = func
+            let sig = &func.sig;
+
+            let func_name = sig.ident.to_string();
+            let args: TokenStream = sig
                 .inputs
                 .iter()
                 .filter_map(|arg| match arg {
@@ -298,9 +309,15 @@ fn generate_public_interface(impl_body: &ItemImpl) -> TokenStream {
                 })
                 .collect();
 
-            quote_spanned! { func.span() =>
-                #func {
-                    (*self).call(#func_name, &[#args]).to()
+            let receiver = if func.is_mut {
+                quote_spanned! { sig.span() => (*self) }
+            } else {
+                quote_spanned! { sig.span() => (*self).clone() }
+            };
+
+            quote_spanned! { sig.span() =>
+                #sig {
+                    #receiver.call(#func_name, &[#args]).to()
                 }
             }
         })
@@ -315,7 +332,7 @@ fn generate_public_interface(impl_body: &ItemImpl) -> TokenStream {
 
         #[automatically_derived]
         #[allow(dead_code)]
-        impl #trait_name for ::godot_rust_script::RsRef<#impl_target> {
+        impl #trait_name for ::godot_rust_script::Rs<#impl_target> {
             #function_impls
         }
     }

--- a/integration-test/src/scripts/test_script.rs
+++ b/integration-test/src/scripts/test_script.rs
@@ -9,7 +9,7 @@ use godot::classes::{Node, Node3D};
 use godot::obj::{Gd, NewAlloc};
 use godot::register::info::PropertyHint;
 use godot_rust_script::{
-    CastToScript, Context, GodotScript, GodotScriptEnum, OnEditor, RsRef, ScriptExportGroup,
+    CastToScript, Context, GodotScript, GodotScriptEnum, OnEditor, Rs, RsDynify, ScriptExportGroup,
     ScriptExportSubgroup, ScriptSignal, godot_script_impl,
 };
 
@@ -43,7 +43,7 @@ struct TestScript {
     pub ready_base: ScriptSignal<Gd<Node>>,
 
     #[signal]
-    pub ready_self: ScriptSignal<RsRef<TestScript>>,
+    pub ready_self: ScriptSignal<Rs<TestScript>>,
 
     pub node_prop: Option<Gd<Node3D>>,
 
@@ -64,11 +64,11 @@ struct TestScript {
     pub custom_enum: ScriptEnum,
 
     #[export]
-    pub script_ref_opt: Option<RsRef<TestScript>>,
+    pub script_ref_opt: Option<Rs<TestScript>>,
 
     #[export_subgroup(name = "Refs")]
     #[export(custom(hint = PropertyHint::NODE_TYPE, hint_string = ""))]
-    pub script_ref: OnEditor<RsRef<TestScript>>,
+    pub script_ref: OnEditor<Rs<TestScript>>,
 
     /// Optional property group that can be toggled.
     #[cfg(since_api = "4.5")]
@@ -117,8 +117,28 @@ impl TestScript {
 
         ctx.reentrant_scope(self, |mut base: Gd<Node>| {
             base.set_owner(&Node::new_alloc());
+            let script = base.to_script::<Self>();
+            let mut trait_obj = script.into_trait::<dyn ScriptTrait>();
+
+            trait_obj.trait_function(10);
         });
 
         result
+    }
+}
+
+trait ScriptTrait {
+    fn trait_function(&mut self, value: u8);
+}
+
+impl<T: ITestScript> ScriptTrait for T {
+    fn trait_function(&mut self, value: u8) {
+        self.record(value);
+    }
+}
+
+impl RsDynify<dyn ScriptTrait> for TestScript {
+    fn coerce(source: Rs<Self>) -> Box<dyn ScriptTrait> {
+        Box::new(source) as Box<dyn ScriptTrait>
     }
 }

--- a/rust-script/src/interface.rs
+++ b/rust-script/src/interface.rs
@@ -31,6 +31,8 @@ pub use property_group::{
 #[expect(deprecated)]
 pub use signals::{ScriptSignal, Signal};
 
+// ----------------------------------------- Godot Rust Script -----------------------------------------
+
 pub trait GodotScript: Debug + GodotScriptImpl<ImplBase = Self::Base> {
     type Base: Inherits<Object>;
 
@@ -62,13 +64,22 @@ pub trait GodotScriptImpl {
     ) -> Result<Variant, godot::meta::error::CallErrorType>;
 }
 
+// ----------------------------------------- Rust Script Reference -----------------------------------------
+
+/// A Godot rust script reference.
+///
+/// This type represents a Godot rust script that is known to have a script of type `T` attached. The script reference allows calling
+/// public methods of the script without having to resort to using `Object::call`.
 #[derive(Debug)]
-pub struct RsRef<T: GodotScript> {
+pub struct Rs<T: GodotScript> {
     owner: Gd<T::Base>,
     script_ty: PhantomData<T>,
 }
 
-impl<T: GodotScript> RsRef<T> {
+#[deprecated(note = "Has been renamed to Rs<T>.")]
+pub type RsRef<T> = Rs<T>;
+
+impl<T: GodotScript> Rs<T> {
     pub(crate) fn new<B: Inherits<T::Base> + Inherits<Object>>(owner: Gd<B>) -> Self {
         Self {
             owner: owner.upcast(),
@@ -97,9 +108,36 @@ impl<T: GodotScript> RsRef<T> {
             GodotScriptCastError::ClassMismatch(T::CLASS_NAME, script.get_class().to_string())
         })
     }
+
+    /// Coerce a script reference into a trait object.
+    ///
+    /// The trait `RsDynify<dyn Trait>` must be implemented for a script type for it to be coerce-able. Implementing the trait requires a single line.
+    ///
+    /// ```rs
+    /// # trait ScriptTrait {}
+    /// #
+    /// # #[derive(GodotScript)]
+    /// # struct TestScript;
+    /// #
+    /// # #[godot_script_impl]
+    /// # impl TestScript {}
+    /// #
+    /// impl RsDynify<dyn ScriptTrait> for TestScript {
+    ///     fn coherce(source: Rs<Self>) -> Box<dyn ScriptTrait> {
+    ///         Box::new(source) as Box<dyn ScriptTrait>
+    ///     }
+    /// }
+    /// ```
+    /// An attribute macro will likely be provided in the future.
+    pub fn into_trait<Trait: ?Sized>(self) -> RsDyn<Trait>
+    where
+        T: RsDynify<Trait>,
+    {
+        RsDynify::wrap(self)
+    }
 }
 
-impl<T: GodotScript> Deref for RsRef<T> {
+impl<T: GodotScript> Deref for Rs<T> {
     type Target = Gd<T::Base>;
 
     fn deref(&self) -> &Self::Target {
@@ -107,13 +145,13 @@ impl<T: GodotScript> Deref for RsRef<T> {
     }
 }
 
-impl<T: GodotScript> DerefMut for RsRef<T> {
+impl<T: GodotScript> DerefMut for Rs<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.owner
     }
 }
 
-impl<T: GodotScript> Clone for RsRef<T> {
+impl<T: GodotScript> Clone for Rs<T> {
     fn clone(&self) -> Self {
         Self {
             owner: self.owner.clone(),
@@ -122,7 +160,7 @@ impl<T: GodotScript> Clone for RsRef<T> {
     }
 }
 
-impl<T: GodotScript> GodotConvert for RsRef<T> {
+impl<T: GodotScript> GodotConvert for Rs<T> {
     type Via = Gd<T::Base>;
 
     fn godot_shape() -> GodotShape {
@@ -130,7 +168,7 @@ impl<T: GodotScript> GodotConvert for RsRef<T> {
     }
 }
 
-impl<T: GodotScript> FromGodot for RsRef<T>
+impl<T: GodotScript> FromGodot for Rs<T>
 where
     T::Base: Inherits<T::Base>,
 {
@@ -139,7 +177,7 @@ where
     }
 }
 
-impl<T: GodotScript> ToGodot for RsRef<T> {
+impl<T: GodotScript> ToGodot for Rs<T> {
     type Pass = ByValue;
 
     fn to_godot(&self) -> Self::Via {
@@ -147,7 +185,7 @@ impl<T: GodotScript> ToGodot for RsRef<T> {
     }
 }
 
-impl<T: GodotScript> ::godot::prelude::Var for RsRef<T>
+impl<T: GodotScript> ::godot::prelude::Var for Rs<T>
 where
     Self: GodotConvert,
 {
@@ -170,6 +208,50 @@ where
     }
 }
 
+// ----------------------------------------- Rust Script Trait Object Ref -----------------------------------------
+
+/// Godot rust script reference as a trait object.
+///
+/// It is possible to implement traits for Godot rust scripts.
+#[derive(Debug)]
+pub struct RsDyn<T: ?Sized> {
+    owner: Box<T>,
+}
+
+/// Support trait for dynamic trait coercion.
+///
+/// Any script type that implements a trait must also implement this trait for the script trait to be accessible.
+///
+/// See [`Rs::into_trait`].
+#[diagnostic::on_unimplemented(
+    message = "Unable to create trait object {T} from Rs<{Self}>",
+    label = "Conversion not implemented",
+    note = "If {T} is implemented for Rs<{Self}>, you also have to implement RsDynify<{T}> for {Self}"
+)]
+pub trait RsDynify<T: ?Sized>: Sized + GodotScript {
+    fn coerce(source: Rs<Self>) -> Box<T>;
+
+    fn wrap(value: Rs<Self>) -> RsDyn<T> {
+        RsDyn {
+            owner: Self::coerce(value),
+        }
+    }
+}
+
+impl<T: ?Sized> Deref for RsDyn<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.owner
+    }
+}
+
+impl<T: ?Sized> DerefMut for RsDyn<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.owner
+    }
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum GodotScriptCastError {
     #[error("Object has no script attached!")]
@@ -184,31 +266,54 @@ pub enum GodotScriptCastError {
     ClassMismatch(&'static str, String),
 }
 
-pub trait CastToScript<T: GodotScript> {
-    fn try_to_script(&self) -> Result<RsRef<T>, GodotScriptCastError>;
-    fn try_into_script(self) -> Result<RsRef<T>, GodotScriptCastError>;
-    fn to_script(&self) -> RsRef<T>;
-    fn into_script(self) -> RsRef<T>;
+pub trait CastToScript {
+    type Base: Inherits<Object>;
+
+    fn try_to_script<T: GodotScript>(&self) -> Result<Rs<T>, GodotScriptCastError>
+    where
+        Self::Base: Inherits<T::Base>;
+    fn try_into_script<T: GodotScript>(self) -> Result<Rs<T>, GodotScriptCastError>
+    where
+        Self::Base: Inherits<T::Base>;
+
+    fn to_script<T: GodotScript>(&self) -> Rs<T>
+    where
+        Self::Base: Inherits<T::Base>;
+
+    fn into_script<T: GodotScript>(self) -> Rs<T>
+    where
+        Self::Base: Inherits<T::Base>;
 }
 
-impl<T: GodotScript, B: Inherits<T::Base> + Inherits<Object>> CastToScript<T> for Gd<B> {
-    fn try_to_script(&self) -> Result<RsRef<T>, GodotScriptCastError> {
-        if let Some(err) = RsRef::<T>::validate_script(self) {
+impl<B: Inherits<Object>> CastToScript for Gd<B> {
+    type Base = B;
+
+    fn try_to_script<T: GodotScript>(&self) -> Result<Rs<T>, GodotScriptCastError>
+    where
+        Self::Base: Inherits<T::Base>,
+    {
+        if let Some(err) = Rs::<T>::validate_script(self) {
             return Err(err);
         }
 
-        Ok(RsRef::new(self.clone()))
+        Ok(Rs::new(self.clone()))
     }
 
-    fn try_into_script(self) -> Result<RsRef<T>, GodotScriptCastError> {
-        if let Some(err) = RsRef::<T>::validate_script(&self) {
+    fn try_into_script<T: GodotScript>(self) -> Result<Rs<T>, GodotScriptCastError>
+    where
+        Self::Base: Inherits<T::Base>,
+    {
+        if let Some(err) = Rs::<T>::validate_script(&self) {
             return Err(err);
         }
 
-        Ok(RsRef::new(self))
+        Ok(Rs::new(self))
     }
 
-    fn to_script(&self) -> RsRef<T> {
+    fn to_script<T: GodotScript>(&self) -> Rs<T>
+    where
+        Self::Base: Inherits<T::Base>,
+    {
         self.try_to_script().unwrap_or_else(|err| {
             panic!(
                 "`{}` was assumed to have rust script `{}`, but this was not the case at runtime!\nError: {}",
@@ -219,7 +324,10 @@ impl<T: GodotScript, B: Inherits<T::Base> + Inherits<Object>> CastToScript<T> fo
         })
     }
 
-    fn into_script(self) -> RsRef<T> {
+    fn into_script<T: GodotScript>(self) -> Rs<T>
+    where
+        Self::Base: Inherits<T::Base>,
+    {
         self.try_into_script().unwrap_or_else(|err| {
             panic!(
                 "`{}` was assumed to have rust script `{}`, but this was not the case at runtime!\nError: {}",

--- a/rust-script/src/interface/export.rs
+++ b/rust-script/src/interface/export.rs
@@ -21,7 +21,7 @@ use godot::register::info::PropertyHint;
 use godot::register::property::BuiltinExport;
 use godot::sys::GodotFfi;
 
-use super::{GodotScript, OnEditor, RsRef};
+use super::{GodotScript, OnEditor, Rs};
 
 pub trait GodotScriptExport {
     fn hint_string(custom_hint: Option<PropertyHint>, custom_string: Option<String>) -> String;
@@ -53,7 +53,7 @@ impl<T: GodotClass> GodotScriptExport for Gd<T> {
     }
 }
 
-impl<T: GodotScript> GodotScriptExport for RsRef<T> {
+impl<T: GodotScript> GodotScriptExport for Rs<T> {
     fn hint_string(_custom_hint: Option<PropertyHint>, custom_string: Option<String>) -> String {
         if let Some(custom) = custom_string {
             return custom;
@@ -123,7 +123,7 @@ where
     }
 }
 
-impl<T: GodotScript> BuiltinExport for RsRef<T> {}
+impl<T: GodotScript> BuiltinExport for Rs<T> {}
 
 macro_rules! default_export {
     ($ty:ty) => {

--- a/rust-script/src/interface/signals.rs
+++ b/rust-script/src/interface/signals.rs
@@ -16,7 +16,7 @@ use godot::meta::{GodotConvert, ToGodot};
 use godot::obj::{Gd, GodotClass};
 
 use crate::static_script_registry::RustScriptPropDesc;
-use crate::{GodotScript, RsRef};
+use crate::{GodotScript, Rs};
 
 use super::GetScriptProperty;
 
@@ -165,7 +165,7 @@ impl<T: GodotClass> SignalArguments for Gd<T> {
     }
 }
 
-impl<T: GodotScript> SignalArguments for RsRef<T> {
+impl<T: GodotScript> SignalArguments for Rs<T> {
     const COUNT: u8 = 1;
 
     fn to_variants(&self) -> Vec<Variant> {


### PR DESCRIPTION
The generic type on the `CastToScript` trait is a pain to work with. The generic type has moved to the functions, making it significantly simpler to specify the target script type.

Additionally, `RsDyn` has been introduced to enable the coercion of `Rs<ScriptType>` values to a trait object.